### PR TITLE
feat: add support for custom environment slugs with `--allow-custom-env` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following options are available through the CLI:
 
 ##### `--allow-custom-env`
 
-Allow custom Vercel environment slugs (e.g. `staging`).
+Allow custom Vercel environment names (e.g. `staging`).
 
 ```shell
 $ pnpm vercel-env-push .env.local staging --allow-custom-env

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ or use it directly with `npx`:
 $ npx vercel-env-push <file> <env> [...otherEnvs]
 ```
 
-The `file` argument is the path to the .env file containing the environment variables to push. The `env` argument is the target environment. By default, supported environments are `development`, `preview` and `production`. You can specify multiple environments by separating them with spaces. To target a custom environment slug (e.g. `staging`), use `--allow-custom-env`.
+The `file` argument is the path to the .env file containing the environment variables to push. The `env` argument is the target environment. By default, supported environments are `development`, `preview` and `production`. You can specify multiple environments by separating them with spaces. To target a custom environment name (e.g. `staging`), use `--allow-custom-env`.
 
 > **Warning**
 > Due to the way the Vercel CLI works, if you have pre-existing environment variables associated to multiple environments (e.g. created through the Vercel Dashboard UI), running `vercel-env-push` to push environment variables to a single environment will remove the environment variables associated to the other environments. Note that environment variables pushed to multiple environments with `vercel-env-push` do not have this limitation as `vercel-env-push` will create a new environment variable for each environment instead of a single one shared across multiple environments.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ await pushEnvVars('.env.local', ['preview', 'production'])
 
 ##### `allowCustomEnv`
 
-Allows custom Vercel environment slugs (e.g. `staging`) in addition to the default environments.
+Allows custom Vercel environment names (e.g. `staging`) in addition to the default environments.
 
 ```ts
 import { pushEnvVars } from 'vercel-env-push'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ or use it directly with `npx`:
 $ npx vercel-env-push <file> <env> [...otherEnvs]
 ```
 
-The `file` argument is the path to the .env file containing the environment variables to push. The `env` argument is the name of the environment to push the environment variables to (the supported environments are `development`, `preview` and `production`). You can specify multiple environments by separating them with spaces.
+The `file` argument is the path to the .env file containing the environment variables to push. The `env` argument is the target environment. By default, supported environments are `development`, `preview` and `production`. You can specify multiple environments by separating them with spaces. To target a custom environment slug (e.g. `staging`), use `--allow-custom-env`.
 
 > **Warning**
 > Due to the way the Vercel CLI works, if you have pre-existing environment variables associated to multiple environments (e.g. created through the Vercel Dashboard UI), running `vercel-env-push` to push environment variables to a single environment will remove the environment variables associated to the other environments. Note that environment variables pushed to multiple environments with `vercel-env-push` do not have this limitation as `vercel-env-push` will create a new environment variable for each environment instead of a single one shared across multiple environments.
@@ -67,6 +67,14 @@ $ pnpm vercel-env-push .env.local preview production
 #### Options
 
 The following options are available through the CLI:
+
+##### `--allow-custom-env`
+
+Allow custom Vercel environment slugs (e.g. `staging`).
+
+```shell
+$ pnpm vercel-env-push .env.local staging --allow-custom-env
+```
 
 ##### `--dry, --dry-run`
 
@@ -136,6 +144,18 @@ await pushEnvVars('.env.local', ['preview', 'production'])
 ```
 
 #### Options
+
+##### `allowCustomEnv`
+
+Allows custom Vercel environment slugs (e.g. `staging`) in addition to the default environments.
+
+```ts
+import { pushEnvVars } from 'vercel-env-push'
+
+await pushEnvVars('.env.local', ['staging'], {
+  allowCustomEnv: true,
+})
+```
 
 ##### `token`
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ pnpm vercel-env-push .env.local preview production
 
 The following options are available through the CLI:
 
-##### `--allow-custom-env`
+##### `--allow-custom-env`, `--custom-env`
 
 Allow custom Vercel environment names (e.g. `staging`).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ cli.version(version).help((sections) => {
 
 cli
   .command('<file> <env> [...otherEnvs]')
-  .option('--allow-custom-env, --custom-env', 'Allow custom environment slugs (e.g. staging)')
+  .option('--allow-custom-env, --custom-env', 'Allow custom environment names (e.g. staging, app-qa, qa_team)')
   .option('--dry, --dry-run', 'List environment variables without pushing them')
   .option('-t, --token <token>', 'Login token to use for pushing environment variables')
   .option('-b, --branch <branch>', 'Specific git branch for pushed preview environment variables')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ const cli = cac('vercel-env-push')
 
 cli.version(version).help((sections) => {
   sections.splice(3, 0, {
-    body: 'Default environments: development - preview - production (use --allow-custom-env for custom slugs)',
+    body: 'Default environments: development - preview - production (use --allow-custom-env for custom environments)',
   })
 })
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,13 +15,19 @@ cli.version(version).help((sections) => {
 
 cli
   .command('<file> <env> [...otherEnvs]')
-  .option('--allow-custom-env', 'Allow custom environment slugs (e.g. staging)')
+  .option('--allow-custom-env, --custom-env', 'Allow custom environment slugs (e.g. staging)')
   .option('--dry, --dry-run', 'List environment variables without pushing them')
   .option('-t, --token <token>', 'Login token to use for pushing environment variables')
   .option('-b, --branch <branch>', 'Specific git branch for pushed preview environment variables')
   .option('-y, --yes', 'Skip confirmation prompt for pushing environment variables')
   .action(async (file: string, env: string, otherEnvs: string[], options: CliOptions) => {
-    await pushEnvVars(file, [env, ...otherEnvs], { ...options, interactive: true })
+    const { allowCustomEnv, customEnv, ...otherOptions } = options
+
+    await pushEnvVars(file, [env, ...otherEnvs], {
+      ...otherOptions,
+      allowCustomEnv: customEnv ?? allowCustomEnv,
+      interactive: true,
+    })
   })
 
 async function run() {
@@ -47,6 +53,7 @@ run()
 interface CliOptions {
   allowCustomEnv?: boolean
   branch?: string
+  customEnv?: boolean
   dryRun?: boolean
   token?: string
   yes?: boolean

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,12 +9,13 @@ const cli = cac('vercel-env-push')
 
 cli.version(version).help((sections) => {
   sections.splice(3, 0, {
-    body: 'Environments: development - preview - production',
+    body: 'Default environments: development - preview - production (use --allow-custom-env for custom slugs)',
   })
 })
 
 cli
   .command('<file> <env> [...otherEnvs]')
+  .option('--allow-custom-env', 'Allow custom environment slugs (e.g. staging)')
   .option('--dry, --dry-run', 'List environment variables without pushing them')
   .option('-t, --token <token>', 'Login token to use for pushing environment variables')
   .option('-b, --branch <branch>', 'Specific git branch for pushed preview environment variables')
@@ -44,6 +45,7 @@ async function run() {
 run()
 
 interface CliOptions {
+  allowCustomEnv?: boolean
   branch?: string
   dryRun?: boolean
   token?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { pluralize } from './libs/string'
 import { replaceEnvVars, validateVercelEnvs } from './libs/vercel'
 
 export async function pushEnvVars(envFilePath: string, envs: string[], options?: Options) {
-  validateVercelEnvs(envs, options?.branch)
+  validateVercelEnvs(envs, { allowCustomEnv: options?.allowCustomEnv, branch: options?.branch })
 
   validateFile(envFilePath)
 
@@ -68,13 +68,20 @@ function logParams(envFilePath: string, envs: string[], branch?: string) {
 
     return `Preparing environment variables push from ${cyan(`'${envFilePath}'`)} to ${formatter.format(
       envs.map((env) => {
-        if (env === 'development') {
-          return green(env)
-        } else if (env === 'preview') {
-          return yellow(`${env}${branch ? ` (branch: ${branch})` : ''}`)
+        switch (env) {
+          case 'development': {
+            return green(env)
+          }
+          case 'preview': {
+            return yellow(`${env}${branch ? ` (branch: ${branch})` : ''}`)
+          }
+          case 'production': {
+            return red(env)
+          }
+          default: {
+            return cyan(`${env} (custom)`)
+          }
         }
-
-        return red(env)
       })
     )}.`
   })
@@ -89,6 +96,7 @@ function logEnvVars(envVars: EnvVars, envVarsCount: number) {
 }
 
 interface Options {
+  allowCustomEnv?: boolean
   branch?: string
   dryRun?: boolean
   interactive?: boolean

--- a/src/libs/vercel.ts
+++ b/src/libs/vercel.ts
@@ -6,18 +6,24 @@ import { type EnvVars } from './file'
 import { exec, isExecError } from './process'
 import { throwIfAnyRejected } from './promise'
 
-const vercelEnvs = ['development', 'preview', 'production'] as const
+const knownVercelEnvs = ['development', 'preview', 'production'] as const
+const customVercelEnvRegex = /^[\da-z][\da-z-]*$/
 
 let waitForRateLimiter: ReturnType<typeof wyt>
 
-export function validateVercelEnvs(envs: string[], branch?: string): asserts envs is VercelEnv[] {
+export function validateVercelEnvs(envs: string[], options?: ValidateVercelEnvsOptions): asserts envs is VercelEnv[] {
   assert(envs.length > 0, 'No environments specified.')
 
   for (const env of envs) {
-    assert((vercelEnvs as ReadonlyArray<string>).includes(env), `Unknown environment '${env}' specified.`)
+    if (isKnownVercelEnv(env)) {
+      continue
+    }
+
+    assert(options?.allowCustomEnv, `Unknown environment '${env}' specified.`)
+    assert(customVercelEnvRegex.test(env), `Invalid custom environment '${env}' specified.`)
   }
 
-  if (branch && branch.length > 0) {
+  if (options?.branch && options.branch.length > 0) {
     assert(
       envs.length === 1 && envs[0] === 'preview',
       'Only the preview environment can be specified when specifying a branch.'
@@ -108,7 +114,17 @@ function rateLimit() {
   waitForRateLimiter = wyt(6, 10_000)
 }
 
-type VercelEnv = typeof vercelEnvs[number]
+function isKnownVercelEnv(env: string): env is KnownVercelEnv {
+  return (knownVercelEnvs as ReadonlyArray<string>).includes(env)
+}
+
+type KnownVercelEnv = typeof knownVercelEnvs[number]
+type VercelEnv = string
+
+interface ValidateVercelEnvsOptions {
+  allowCustomEnv?: boolean
+  branch?: string
+}
 
 interface VercelOptions {
   branch?: string

--- a/src/libs/vercel.ts
+++ b/src/libs/vercel.ts
@@ -7,7 +7,7 @@ import { exec, isExecError } from './process'
 import { throwIfAnyRejected } from './promise'
 
 const knownVercelEnvs = ['development', 'preview', 'production'] as const
-const customVercelEnvRegex = /^[\da-z][\da-z-]*$/
+const customVercelEnvRegex = /^[\d_a-z-]+$/
 
 let waitForRateLimiter: ReturnType<typeof wyt>
 

--- a/test/vercel.test.ts
+++ b/test/vercel.test.ts
@@ -64,7 +64,7 @@ describe('env', () => {
     )
   })
 
-  test.todo('should throw if a git branch is specified with an environment that is not preview', async () => {
+  test('should throw if a git branch is specified with a known environment that is not preview', async () => {
     await expect(pushEnvVars('', ['production'], { branch: 'test-branch' })).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Only the preview environment can be specified when specifying a branch."'
     )

--- a/test/vercel.test.ts
+++ b/test/vercel.test.ts
@@ -36,9 +36,29 @@ describe('env', () => {
     )
   })
 
+  test('should allow a custom environment when explicitly enabled', async () => {
+    await expect(
+      pushEnvVars('test/fixtures/.env.test', ['staging'], { allowCustomEnv: true, dryRun: true })
+    ).resolves.toBeUndefined()
+  })
+
+  test('should throw if an invalid custom environment is provided', async () => {
+    await expect(pushEnvVars('', ['Staging'], { allowCustomEnv: true })).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Invalid custom environment \'Staging\' specified."'
+    )
+  })
+
   test('should throw if a git branch is specified with more than 1 environment', async () => {
     await expect(
       pushEnvVars('', ['preview', 'production'], { branch: 'test-branch' })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Only the preview environment can be specified when specifying a branch."'
+    )
+  })
+
+  test('should throw if a git branch is specified with a custom environment', async () => {
+    await expect(
+      pushEnvVars('', ['staging'], { allowCustomEnv: true, branch: 'test-branch' })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Only the preview environment can be specified when specifying a branch."'
     )


### PR DESCRIPTION
**Describe the pull request**

Hey there 👋 We've multiple custom environments in Vercel, and we want to migrate our current bash-based scripts to `vercel-env-push`

**Why**

Pro and Enterprise teams can create Custom Environments for more specialized workflows (e.g., staging, QA)

https://vercel.com/docs/deployments/environments